### PR TITLE
Add types for trailing-slash-it

### DIFF
--- a/types/trailing-slash-it/index.d.ts
+++ b/types/trailing-slash-it/index.d.ts
@@ -1,0 +1,10 @@
+// Type definitions for trailing-slash-it 0.3
+// Project: https://github.com/misund/trailing-slash-it#readme
+// Definitions by: Craig Morris <https://github.com/me>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/*~ If this module has methods, declare them as functions like so.
+ */
+export function trailingSlashIt(a: string): string;
+export function unTrailingSlashIt(a: string): string;
+export default function trailingSlashIt(a: string): string

--- a/types/trailing-slash-it/trailing-slash-it-tests.ts
+++ b/types/trailing-slash-it/trailing-slash-it-tests.ts
@@ -1,0 +1,5 @@
+import slash, { trailingSlashIt, unTrailingSlashIt } from "trailing-slash-it";
+
+slash('foo\\bar'); // $ExpectType string
+trailingSlashIt('foo\\bar'); // $ExpectType string
+unTrailingSlashIt('foo\\bar'); // $ExpectType string

--- a/types/trailing-slash-it/tsconfig.json
+++ b/types/trailing-slash-it/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "trailing-slash-it-tests.ts"
+    ]
+}

--- a/types/trailing-slash-it/tslint.json
+++ b/types/trailing-slash-it/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.